### PR TITLE
Rescue from XML parse error when SAMLResponse contains newline chars

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -68,6 +68,16 @@ module OmniAuth
         fail!(:invalid_ticket, $!)
       rescue OneLogin::RubySaml::ValidationError
         fail!(:invalid_ticket, $!)
+      rescue REXML::ParseException
+        request.params['SAMLResponse'] = clean_newlines
+        retry
+      end
+
+      # remove newline characters if they're included in the SAMLResponse
+      def clean_newlines
+        if request.params['SAMLResponse'].include?('\\r\\n')
+          request.params['SAMLResponse'].gsub('\\r\\n', '')
+        end
       end
 
       # Obtain an idp certificate fingerprint from the response.


### PR DESCRIPTION
**Why**
We are receiving SAMLResponse params that contain newline characters when URI decoded. This was
causing an exception in the XML parser and making for a hard to diagnose error.

**How**
Rescuse the error, log the event, and clean the SAMLResponse by removing the newline characters.
